### PR TITLE
fix: extend payload for send/receive buffer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+#Build Flag
+
+FUNCTION=$1
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+export PATH=/usr/local/go/bin:$PATH
+export PATH=$HOME/go/bin:$PATH
+
+CreateEnv() {
+    sudo apt-get update && sudo apt upgrade -y
+    sudo apt-get install make build-essential gcc git jq chrony -y
+    wget https://golang.org/dl/go1.18.1.linux-amd64.tar.gz
+    sudo tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz
+    rm -rf go1.18.1.linux-amd64.tar.gz
+
+    export GOROOT=/usr/local/go
+    export GOPATH=$HOME/go
+    export GO111MODULE=on
+    export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+
+    ########### install cargo ###########
+    sudo apt-get update
+    sudo apt-get -y install cargo
+
+    ########### Rustc setup ##########
+    sudo apt install -y curl gcc make build-essential
+    curl https://sh.rustup.rs -sSf | sh
+    source ~/.profile
+    source ~/.cargo/env
+
+    rustup default stable
+    rustup target add wasm32-unknown-unknown
+}
+
+######################### Build and Clean ###############
+
+Build() {
+
+    mkdir out
+
+    echo "================================================="
+    echo "Rust Build Start"
+    cargo build
+
+    echo "Rust Unit Test"
+    cargo test
+
+    cp -r target/debug/*.d  out/
+    cp -r target/debug/*.so  out/
+    cp -r target/debug/*.rlib out/
+
+    mkdir out/examples
+    cp -R target/debug/examples/client out/examples/
+    cp -R target/debug/examples/server out/examples/
+    
+    rm -rf target
+}
+
+Clean() {
+    rm -rf out
+    rm -rf target
+}
+
+#################################### End of Function ###################################################
+if [[ $FUNCTION == "" ]]; then
+    Build
+else
+    $FUNCTION
+fi

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -162,6 +162,20 @@ where
     }
 }
 
+fn print_buffer_result(result: Result<U16Vec, RequestError>) {
+    match result {
+        Ok(buffer) => {
+            println!("Received data: {}", buffer);
+        }
+        Err(RequestError::Exception(exception)) => {
+            println!("Modbus exception: {}", exception);
+        }
+        Err(err) => {
+            println!("Read error: {}", err);
+        }
+    }
+}
+
 fn print_write_result<T>(result: Result<T, RequestError>) {
     match result {
         Ok(_) => {
@@ -272,13 +286,10 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                 let result = channel
                     .send_custom_buffer(
                         params,
-                        Indexed {
-                            index: (0x1),
-                            value: (0xAB),
-                        },
+                        U16Vec::new(vec![0xAB, 0xCD, 0xEF, 0x12])
                     )
                     .await;
-                print_write_result(result);
+                print_buffer_result(result);
                 // ANCHOR_END: write_multiple_registers
             }
             _ => println!("unknown command"),

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -267,6 +267,20 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                 print_write_result(result);
                 // ANCHOR_END: write_multiple_registers
             }
+            "scb" => {
+                // ANCHOR: send_custom_buffer
+                let result = channel
+                    .send_custom_buffer(
+                        params,
+                        Indexed {
+                            index: (0x1),
+                            value: (0xAB),
+                        },
+                    )
+                    .await;
+                print_write_result(result);
+                // ANCHOR_END: write_multiple_registers
+            }
             _ => println!("unknown command"),
         }
     }

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -78,15 +78,14 @@ impl RequestHandler for SimpleHandler {
         }
     }
 
-    fn receive_custom_buffer(&self, value: Indexed<u16>) -> Result<u16, ExceptionCode> {
+    fn receive_custom_buffer(&self, value: U16Vec) -> Result<(), ExceptionCode> {
         tracing::info!(
-            "receive custom buffer, index: {} value: {}",
-            value.index,
-            value.value
+            "receive custom buffer, {}",
+            value,
         );
 
-        if value.value == 0xAB {
-            Ok(0xCD)
+        if value.len() != 0 {
+            Ok(())
         } else {
             Err(ExceptionCode::IllegalFunction)
         }

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -78,6 +78,20 @@ impl RequestHandler for SimpleHandler {
         }
     }
 
+    fn receive_custom_buffer(&self, value: Indexed<u16>) -> Result<u16, ExceptionCode> {
+        tracing::info!(
+            "receive custom buffer, index: {} value: {}",
+            value.index,
+            value.value
+        );
+
+        if value.value == 0xAB {
+            Ok(0xCD)
+        } else {
+            Err(ExceptionCode::IllegalFunction)
+        }
+    }
+
     fn write_single_register(&mut self, value: Indexed<u16>) -> Result<(), ExceptionCode> {
         tracing::info!(
             "write single register, index: {} value: {}",

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -7,7 +7,7 @@ use crate::client::requests::write_multiple::{MultipleWriteRequest, WriteMultipl
 use crate::client::requests::write_single::SingleWrite;
 use crate::client::requests::send_buffer::SendBuffer;
 use crate::error::*;
-use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId};
+use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId, U16Vec};
 use crate::DecodeLevel;
 
 /// Async channel used to make requests
@@ -168,9 +168,9 @@ impl Channel {
     pub async fn send_custom_buffer(
         &mut self,
         param: RequestParam,
-        request: Indexed<u16>,
-    ) -> Result<Indexed<u16>, RequestError> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<Result<Indexed<u16>, RequestError>>();
+        request: U16Vec,
+    ) -> Result<U16Vec, RequestError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<U16Vec, RequestError>>();
         let request = wrap(
             param,
             RequestDetails::SendCustomBuffers(SendBuffer::new(request, Promise::channel(tx))),

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -5,6 +5,7 @@ use crate::client::requests::read_bits::ReadBits;
 use crate::client::requests::read_registers::ReadRegisters;
 use crate::client::requests::write_multiple::{MultipleWriteRequest, WriteMultiple};
 use crate::client::requests::write_single::SingleWrite;
+use crate::client::requests::send_buffer::SendBuffer;
 use crate::error::*;
 use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId};
 use crate::DecodeLevel;
@@ -158,6 +159,21 @@ impl Channel {
                 range.of_read_registers()?,
                 tx,
             )),
+        );
+        self.tx.send(request).await?;
+        rx.await?
+    }
+
+    /// Send buffer to the server
+    pub async fn send_custom_buffer(
+        &mut self,
+        param: RequestParam,
+        request: Indexed<u16>,
+    ) -> Result<Indexed<u16>, RequestError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<Indexed<u16>, RequestError>>();
+        let request = wrap(
+            param,
+            RequestDetails::SendCustomBuffers(SendBuffer::new(request, Promise::channel(tx))),
         );
         self.tx.send(request).await?;
         rx.await?

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -12,7 +12,7 @@ use crate::client::requests::write_multiple::MultipleWriteRequest;
 use crate::client::requests::write_single::SingleWrite;
 use crate::client::requests::send_buffer::SendBuffer;
 use crate::common::traits::Serialize;
-use crate::types::{Indexed, UnitId};
+use crate::types::{Indexed, UnitId, U16Vec};
 
 use scursor::{ReadCursor, WriteCursor};
 use std::time::Duration;
@@ -36,13 +36,13 @@ pub(crate) struct Request {
     pub(crate) details: RequestDetails,
 }
 
-// possible requests that can be sent through the channel
+// possible requests that can be sent through the channel``
 pub(crate) enum RequestDetails {
     ReadCoils(ReadBits),
     ReadDiscreteInputs(ReadBits),
     ReadHoldingRegisters(ReadRegisters),
     ReadInputRegisters(ReadRegisters),
-    SendCustomBuffers(SendBuffer<Indexed<u16>>),
+    SendCustomBuffers(SendBuffer<U16Vec>),
     WriteSingleCoil(SingleWrite<Indexed<bool>>),
     WriteSingleRegister(SingleWrite<Indexed<u16>>),
     WriteMultipleCoils(MultipleWriteRequest<bool>),
@@ -226,7 +226,7 @@ impl std::fmt::Display for RequestDetailsDisplay<'_> {
                     write!(f, "{}", details.request.get())?;
                 }
                 RequestDetails::SendCustomBuffers(details) => {
-                    write!(f, "{}", details.request)?;
+                    write!(f, "{:?}", details.request)?;
                 }
                 RequestDetails::WriteSingleCoil(details) => {
                     write!(f, "{}", details.request)?;

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -10,6 +10,7 @@ use crate::client::requests::read_bits::ReadBits;
 use crate::client::requests::read_registers::ReadRegisters;
 use crate::client::requests::write_multiple::MultipleWriteRequest;
 use crate::client::requests::write_single::SingleWrite;
+use crate::client::requests::send_buffer::SendBuffer;
 use crate::common::traits::Serialize;
 use crate::types::{Indexed, UnitId};
 
@@ -41,6 +42,7 @@ pub(crate) enum RequestDetails {
     ReadDiscreteInputs(ReadBits),
     ReadHoldingRegisters(ReadRegisters),
     ReadInputRegisters(ReadRegisters),
+    SendCustomBuffers(SendBuffer<Indexed<u16>>),
     WriteSingleCoil(SingleWrite<Indexed<bool>>),
     WriteSingleRegister(SingleWrite<Indexed<u16>>),
     WriteMultipleCoils(MultipleWriteRequest<bool>),
@@ -125,6 +127,7 @@ impl RequestDetails {
             RequestDetails::ReadDiscreteInputs(_) => FunctionCode::ReadDiscreteInputs,
             RequestDetails::ReadHoldingRegisters(_) => FunctionCode::ReadHoldingRegisters,
             RequestDetails::ReadInputRegisters(_) => FunctionCode::ReadInputRegisters,
+            RequestDetails::SendCustomBuffers(_) => FunctionCode::SendCustomBuffers,
             RequestDetails::WriteSingleCoil(_) => FunctionCode::WriteSingleCoil,
             RequestDetails::WriteSingleRegister(_) => FunctionCode::WriteSingleRegister,
             RequestDetails::WriteMultipleCoils(_) => FunctionCode::WriteMultipleCoils,
@@ -138,6 +141,7 @@ impl RequestDetails {
             RequestDetails::ReadDiscreteInputs(x) => x.failure(err),
             RequestDetails::ReadHoldingRegisters(x) => x.failure(err),
             RequestDetails::ReadInputRegisters(x) => x.failure(err),
+            RequestDetails::SendCustomBuffers(x) => x.failure(err),
             RequestDetails::WriteSingleCoil(x) => x.failure(err),
             RequestDetails::WriteSingleRegister(x) => x.failure(err),
             RequestDetails::WriteMultipleCoils(x) => x.failure(err),
@@ -156,6 +160,7 @@ impl RequestDetails {
             RequestDetails::ReadDiscreteInputs(x) => x.handle_response(cursor, function, decode),
             RequestDetails::ReadHoldingRegisters(x) => x.handle_response(cursor, function, decode),
             RequestDetails::ReadInputRegisters(x) => x.handle_response(cursor, function, decode),
+            RequestDetails::SendCustomBuffers(x) => x.handle_response(cursor, function, decode),
             RequestDetails::WriteSingleCoil(x) => x.handle_response(cursor, function, decode),
             RequestDetails::WriteSingleRegister(x) => x.handle_response(cursor, function, decode),
             RequestDetails::WriteMultipleCoils(x) => x.handle_response(cursor, function, decode),
@@ -173,6 +178,7 @@ impl Serialize for RequestDetails {
             RequestDetails::ReadDiscreteInputs(x) => x.serialize(cursor),
             RequestDetails::ReadHoldingRegisters(x) => x.serialize(cursor),
             RequestDetails::ReadInputRegisters(x) => x.serialize(cursor),
+            RequestDetails::SendCustomBuffers(x) => x.serialize(cursor),
             RequestDetails::WriteSingleCoil(x) => x.serialize(cursor),
             RequestDetails::WriteSingleRegister(x) => x.serialize(cursor),
             RequestDetails::WriteMultipleCoils(x) => x.serialize(cursor),
@@ -218,6 +224,9 @@ impl std::fmt::Display for RequestDetailsDisplay<'_> {
                 }
                 RequestDetails::ReadInputRegisters(details) => {
                     write!(f, "{}", details.request.get())?;
+                }
+                RequestDetails::SendCustomBuffers(details) => {
+                    write!(f, "{}", details.request)?;
                 }
                 RequestDetails::WriteSingleCoil(details) => {
                     write!(f, "{}", details.request)?;

--- a/rodbus/src/client/requests/mod.rs
+++ b/rodbus/src/client/requests/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod read_bits;
 pub(crate) mod read_registers;
 pub(crate) mod write_multiple;
 pub(crate) mod write_single;
+pub(crate) mod send_buffer;

--- a/rodbus/src/client/requests/send_buffer.rs
+++ b/rodbus/src/client/requests/send_buffer.rs
@@ -1,0 +1,94 @@
+use std::fmt::Display;
+
+use crate::client::message::Promise;
+use crate::common::function::FunctionCode;
+use crate::decode::AppDecodeLevel;
+use crate::error::AduParseError;
+use crate::error::RequestError;
+use crate::types::{coil_from_u16, coil_to_u16, Indexed};
+
+use scursor::{ReadCursor, WriteCursor};
+
+pub(crate) trait SendBufferOperation: Sized + PartialEq {
+    fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError>;
+    fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError>;
+}
+
+pub(crate) struct SendBuffer<T>
+where
+    T: SendBufferOperation + Display + Send + 'static,
+{
+    pub(crate) request: T,
+    promise: Promise<T>,
+}
+
+impl<T> SendBuffer<T>
+where
+    T: SendBufferOperation + Display + Send + 'static,
+{
+    pub(crate) fn new(request: T, promise: Promise<T>) -> Self {
+        Self { request, promise }
+    }
+
+    pub(crate) fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError> {
+        self.request.serialize(cursor)
+    }
+
+    pub(crate) fn failure(&mut self, err: RequestError) {
+        self.promise.failure(err)
+    }
+
+    pub(crate) fn handle_response(
+        &mut self,
+        cursor: ReadCursor,
+        function: FunctionCode,
+        decode: AppDecodeLevel,
+    ) -> Result<(), RequestError> {
+        let response = self.parse_all(cursor)?;
+
+        if decode.data_headers() {
+            tracing::info!("PDU RX - {} {}", function, response);
+        } else if decode.header() {
+            tracing::info!("PDU RX - {}", function);
+        }
+
+        self.promise.success(response);
+        Ok(())
+    }
+
+    fn parse_all(&self, mut cursor: ReadCursor) -> Result<T, RequestError> {
+        let response = T::parse(&mut cursor)?;
+        cursor.expect_empty()?;
+        if self.request != response {
+            return Err(AduParseError::ReplyEchoMismatch.into());
+        }
+        Ok(response)
+    }
+}
+
+impl SendBufferOperation for Indexed<bool> {
+    fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError> {
+        cursor.write_u16_be(self.index)?;
+        cursor.write_u16_be(coil_to_u16(self.value))?;
+        Ok(())
+    }
+
+    fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
+        Ok(Indexed::new(
+            cursor.read_u16_be()?,
+            coil_from_u16(cursor.read_u16_be()?)?,
+        ))
+    }
+}
+
+impl SendBufferOperation for Indexed<u16> {
+    fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError> {
+        cursor.write_u16_be(self.index)?;
+        cursor.write_u16_be(self.value)?;
+        Ok(())
+    }
+
+    fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
+        Ok(Indexed::new(cursor.read_u16_be()?, cursor.read_u16_be()?))
+    }
+}

--- a/rodbus/src/common/function.rs
+++ b/rodbus/src/common/function.rs
@@ -9,6 +9,7 @@ mod constants {
     pub(crate) const WRITE_SINGLE_REGISTER: u8 = 6;
     pub(crate) const WRITE_MULTIPLE_COILS: u8 = 15;
     pub(crate) const WRITE_MULTIPLE_REGISTERS: u8 = 16;
+    pub(crate) const SEND_CUSTOM_BUFFERS: u8 = 68;
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -22,6 +23,7 @@ pub(crate) enum FunctionCode {
     WriteSingleRegister = constants::WRITE_SINGLE_REGISTER,
     WriteMultipleCoils = constants::WRITE_MULTIPLE_COILS,
     WriteMultipleRegisters = constants::WRITE_MULTIPLE_REGISTERS,
+    SendCustomBuffers = constants::SEND_CUSTOM_BUFFERS,
 }
 
 impl Display for FunctionCode {
@@ -49,6 +51,9 @@ impl Display for FunctionCode {
             FunctionCode::WriteMultipleRegisters => {
                 write!(f, "WRITE MULTIPLE REGISTERS ({:#04X})", self.get_value())
             }
+            FunctionCode::SendCustomBuffers => {
+                write!(f, "SEND CUSTOM BUFFER ({:#04X})", self.get_value())
+            }
         }
     }
 }
@@ -72,6 +77,7 @@ impl FunctionCode {
             constants::WRITE_SINGLE_REGISTER => Some(FunctionCode::WriteSingleRegister),
             constants::WRITE_MULTIPLE_COILS => Some(FunctionCode::WriteMultipleCoils),
             constants::WRITE_MULTIPLE_REGISTERS => Some(FunctionCode::WriteMultipleRegisters),
+            constants::SEND_CUSTOM_BUFFERS => Some(FunctionCode::SendCustomBuffers),
             _ => None,
         }
     }

--- a/rodbus/src/common/parse.rs
+++ b/rodbus/src/common/parse.rs
@@ -1,6 +1,6 @@
 use crate::common::traits::Parse;
 use crate::error::*;
-use crate::types::{coil_from_u16, AddressRange, Indexed};
+use crate::types::{coil_from_u16, AddressRange, Indexed, U16Vec};
 
 use scursor::ReadCursor;
 
@@ -25,6 +25,16 @@ impl Parse for Indexed<bool> {
 impl Parse for Indexed<u16> {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
         Ok(Indexed::new(cursor.read_u16_be()?, cursor.read_u16_be()?))
+    }
+}
+impl Parse for U16Vec {
+    fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
+        let len = cursor.read_u16_be()? as usize;
+        let mut vec = Vec::with_capacity(len);
+        for _ in 0..len {
+            vec.push(cursor.read_u16_be()?);
+        }
+        Ok(U16Vec::new(vec))  // Construct a U16Vec from the parsed vector
     }
 }
 

--- a/rodbus/src/serial/frame.rs
+++ b/rodbus/src/serial/frame.rs
@@ -83,6 +83,7 @@ impl RtuParser {
                 FunctionCode::ReadDiscreteInputs => LengthMode::Fixed(4),
                 FunctionCode::ReadHoldingRegisters => LengthMode::Fixed(4),
                 FunctionCode::ReadInputRegisters => LengthMode::Fixed(4),
+                FunctionCode::SendCustomBuffers => LengthMode::Offset(1),
                 FunctionCode::WriteSingleCoil => LengthMode::Fixed(4),
                 FunctionCode::WriteSingleRegister => LengthMode::Fixed(4),
                 FunctionCode::WriteMultipleCoils => LengthMode::Offset(5),
@@ -93,6 +94,7 @@ impl RtuParser {
                 FunctionCode::ReadDiscreteInputs => LengthMode::Offset(1),
                 FunctionCode::ReadHoldingRegisters => LengthMode::Offset(1),
                 FunctionCode::ReadInputRegisters => LengthMode::Offset(1),
+                FunctionCode::SendCustomBuffers => LengthMode::Offset(1),
                 FunctionCode::WriteSingleCoil => LengthMode::Fixed(4),
                 FunctionCode::WriteSingleRegister => LengthMode::Fixed(4),
                 FunctionCode::WriteMultipleCoils => LengthMode::Fixed(4),
@@ -345,6 +347,21 @@ mod tests {
         0x71, 0x86, // crc
     ];
 
+    const SEND_CUSTOM_BUFFER_REQUEST: &[u8] = &[
+        UNIT_ID, // unit id
+        0x44, // function code
+        0x02, // byte count   
+        0x01, 0xAB, // additonal data
+        0xC8, 0xD9, // crc
+    ];
+
+    const SEND_CUSTOM_BUFFER_RESPONSE: &[u8] = &[
+        UNIT_ID, // unit id
+        0x44,    // function code
+        0x01, // byte count
+        0xCD, // return value
+        0x88, 0x2C, // crc
+    ];
     const WRITE_SINGLE_COIL_REQUEST: &[u8] = &[
         UNIT_ID, // unit id
         0x05,    // function code
@@ -427,6 +444,10 @@ mod tests {
             FunctionCode::ReadInputRegisters,
             READ_INPUT_REGISTERS_REQUEST,
         ),
+        (
+            FunctionCode::SendCustomBuffers,
+            SEND_CUSTOM_BUFFER_REQUEST,
+        ),
         (FunctionCode::WriteSingleCoil, WRITE_SINGLE_COIL_REQUEST),
         (
             FunctionCode::WriteSingleRegister,
@@ -455,6 +476,10 @@ mod tests {
         (
             FunctionCode::ReadInputRegisters,
             READ_INPUT_REGISTERS_RESPONSE,
+        ),
+        (
+            FunctionCode::SendCustomBuffers,
+            SEND_CUSTOM_BUFFER_RESPONSE,
         ),
         (FunctionCode::WriteSingleCoil, WRITE_SINGLE_COIL_RESPONSE),
         (

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -43,8 +43,8 @@ pub trait RequestHandler: Send + 'static {
         Err(ExceptionCode::IllegalFunction)
     }
 
-    /// Read single custom buffer or return an ExceptionCode
-    fn receive_custom_buffer(&self, _value: Indexed<u16>) -> Result<u16, ExceptionCode> {
+    /// Send custom buffer or return an ExceptionCode
+    fn receive_custom_buffer(&self, _value: U16Vec) -> Result<(), ExceptionCode> {
         Err(ExceptionCode::IllegalFunction)
     }
 
@@ -183,11 +183,7 @@ pub trait AuthorizationHandler: Send + Sync + 'static {
     }
 
     /// Authorize a Read Custom Buffer request
-    fn receive_custom_buffer(
-        &self,
-        _value: Indexed<u16>,
-        _role: &str,
-    ) -> Authorization {
+    fn receive_custom_buffer(&self, _value: U16Vec, _role: &str) -> Authorization {
         Authorization::Deny
     }
     /// Authorize a Read Holding Registers request

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -43,6 +43,11 @@ pub trait RequestHandler: Send + 'static {
         Err(ExceptionCode::IllegalFunction)
     }
 
+    /// Read single custom buffer or return an ExceptionCode
+    fn receive_custom_buffer(&self, _value: Indexed<u16>) -> Result<u16, ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
+
     /// Write a single coil value
     fn write_single_coil(&mut self, _value: Indexed<bool>) -> Result<(), ExceptionCode> {
         Err(ExceptionCode::IllegalFunction)
@@ -177,6 +182,14 @@ pub trait AuthorizationHandler: Send + Sync + 'static {
         Authorization::Deny
     }
 
+    /// Authorize a Read Custom Buffer request
+    fn receive_custom_buffer(
+        &self,
+        _value: Indexed<u16>,
+        _role: &str,
+    ) -> Authorization {
+        Authorization::Deny
+    }
     /// Authorize a Read Holding Registers request
     fn read_holding_registers(
         &self,

--- a/rodbus/src/server/request.rs
+++ b/rodbus/src/server/request.rs
@@ -17,7 +17,7 @@ pub(crate) enum Request<'a> {
     ReadDiscreteInputs(ReadBitsRange),
     ReadHoldingRegisters(ReadRegistersRange),
     ReadInputRegisters(ReadRegistersRange),
-    SendCustomBuffers(Indexed<u16>),
+    SendCustomBuffers(U16Vec),
     WriteSingleCoil(Indexed<bool>),
     WriteSingleRegister(Indexed<u16>),
     WriteMultipleCoils(WriteCoils<'a>),
@@ -127,7 +127,7 @@ impl<'a> Request<'a> {
                 writer.format_reply(header, function, &registers, level)
             }
             Request::SendCustomBuffers(request) => {
-                let result = handler.receive_custom_buffer(*request).map(|_| *request);
+                let result = handler.receive_custom_buffer(request.clone()).map(|_| Indexed {index: (0x1),value: (0xAB),});
                 write_result(function, header, writer, result, level)
             }
             Request::WriteSingleCoil(request) => {
@@ -180,8 +180,7 @@ impl<'a> Request<'a> {
                 Ok(x)
             }
             FunctionCode::SendCustomBuffers => {
-                let x =
-                    Request::SendCustomBuffers(Indexed::<u16>::parse(cursor)?);
+                let x = Request::SendCustomBuffers(U16Vec::parse(cursor)?);
                 cursor.expect_empty()?;
                 Ok(x)
             }

--- a/rodbus/src/server/request.rs
+++ b/rodbus/src/server/request.rs
@@ -17,6 +17,7 @@ pub(crate) enum Request<'a> {
     ReadDiscreteInputs(ReadBitsRange),
     ReadHoldingRegisters(ReadRegistersRange),
     ReadInputRegisters(ReadRegistersRange),
+    SendCustomBuffers(Indexed<u16>),
     WriteSingleCoil(Indexed<bool>),
     WriteSingleRegister(Indexed<u16>),
     WriteMultipleCoils(WriteCoils<'a>),
@@ -60,6 +61,7 @@ impl<'a> Request<'a> {
             Request::ReadDiscreteInputs(_) => FunctionCode::ReadDiscreteInputs,
             Request::ReadHoldingRegisters(_) => FunctionCode::ReadHoldingRegisters,
             Request::ReadInputRegisters(_) => FunctionCode::ReadInputRegisters,
+            Request::SendCustomBuffers(_) => FunctionCode::SendCustomBuffers,
             Request::WriteSingleCoil(_) => FunctionCode::WriteSingleCoil,
             Request::WriteSingleRegister(_) => FunctionCode::WriteSingleRegister,
             Request::WriteMultipleCoils(_) => FunctionCode::WriteMultipleCoils,
@@ -73,6 +75,7 @@ impl<'a> Request<'a> {
             Request::ReadDiscreteInputs(_) => None,
             Request::ReadHoldingRegisters(_) => None,
             Request::ReadInputRegisters(_) => None,
+            Request::SendCustomBuffers(_) => None,
             Request::WriteSingleCoil(x) => Some(BroadcastRequest::WriteSingleCoil(x)),
             Request::WriteSingleRegister(x) => Some(BroadcastRequest::WriteSingleRegister(x)),
             Request::WriteMultipleCoils(x) => Some(BroadcastRequest::WriteMultipleCoils(x)),
@@ -123,6 +126,10 @@ impl<'a> Request<'a> {
                 let registers = RegisterWriter::new(*range, |i| handler.read_input_register(i));
                 writer.format_reply(header, function, &registers, level)
             }
+            Request::SendCustomBuffers(request) => {
+                let result = handler.receive_custom_buffer(*request).map(|_| *request);
+                write_result(function, header, writer, result, level)
+            }
             Request::WriteSingleCoil(request) => {
                 let result = handler.write_single_coil(*request).map(|_| *request);
                 write_result(function, header, writer, result, level)
@@ -169,6 +176,12 @@ impl<'a> Request<'a> {
             FunctionCode::ReadInputRegisters => {
                 let x =
                     Request::ReadInputRegisters(AddressRange::parse(cursor)?.of_read_registers()?);
+                cursor.expect_empty()?;
+                Ok(x)
+            }
+            FunctionCode::SendCustomBuffers => {
+                let x =
+                    Request::SendCustomBuffers(Indexed::<u16>::parse(cursor)?);
                 cursor.expect_empty()?;
                 Ok(x)
             }
@@ -232,6 +245,9 @@ impl std::fmt::Display for RequestDisplay<'_, '_> {
                 }
                 Request::ReadInputRegisters(range) => {
                     write!(f, " {}", range.get())?;
+                }
+                Request::SendCustomBuffers(request) => {
+                    write!(f, " {request}")?;
                 }
                 Request::WriteSingleCoil(request) => {
                     write!(f, " {request}")?;

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -256,7 +256,7 @@ impl AuthorizationType {
                 handler.read_holding_registers(unit_id, x.inner, role)
             }
             Request::ReadInputRegisters(x) => handler.read_input_registers(unit_id, x.inner, role),
-            Request::SendCustomBuffers(x) => handler.receive_custom_buffer(*x, role),
+            Request::SendCustomBuffers(x) => handler.receive_custom_buffer(x.clone(), role),
             Request::WriteSingleCoil(x) => handler.write_single_coil(unit_id, x.index, role),
             Request::WriteSingleRegister(x) => {
                 handler.write_single_register(unit_id, x.index, role)

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -256,6 +256,7 @@ impl AuthorizationType {
                 handler.read_holding_registers(unit_id, x.inner, role)
             }
             Request::ReadInputRegisters(x) => handler.read_input_registers(unit_id, x.inner, role),
+            Request::SendCustomBuffers(x) => handler.receive_custom_buffer(*x, role),
             Request::WriteSingleCoil(x) => handler.write_single_coil(unit_id, x.index, role),
             Request::WriteSingleRegister(x) => {
                 handler.write_single_register(unit_id, x.index, role)

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -80,6 +80,46 @@ pub struct RegisterIterator<'a> {
     pos: u16,
 }
 
+/// A wrapper struct around `Vec<u16>`.
+///
+/// `U16Vec` provides a convenient way to work with vectors of `u16`
+/// while implementing additional traits like `std::fmt::Display` and
+/// `SendBufferOperation`. It's used in scenarios where we need to serialize
+/// and parse sequences of `u16` values.
+
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct U16Vec(Vec<u16>);
+
+impl U16Vec {
+    /// Add a constructor for convenience
+    pub fn new(vec: Vec<u16>) -> Self {
+        U16Vec(vec)
+    }
+
+    /// Helper method to get the length of the inner vector
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Helper method to iterate over the inner vector
+    pub fn iter(&self) -> std::slice::Iter<u16> {
+        self.0.iter()
+    }
+}
+
+impl std::fmt::Display for U16Vec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        for (i, val) in self.0.iter().enumerate() {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", val)?;
+        }
+        write!(f, "]")
+    }
+}
 pub(crate) struct RegisterIteratorDisplay<'a> {
     iterator: RegisterIterator<'a>,
     level: AppDecodeLevel,


### PR DESCRIPTION
## Add
- build.sh
Build; ./build.sh
It will create "out" folder including out files such as .so, .rlib, .d.
In addition example folder including client and server execution files will be created in the "out" folder.
Clean: ./buils.sh Clean 

## Modifies
- Extendable the payload of the buffer
- Send/Receive/Parse logic for extendable payload
- Client/Server examples