### PR TITLE
Feat: Implementation of User-Defined Custom Function Code FC69 (0x45) - Write Custom Function Code

### DIFF
--- a/rodbus/WCFC_README.md
+++ b/rodbus/WCFC_README.md
@@ -1,0 +1,64 @@
+# 69 (0x45) Write Custom Function Code
+
+This document provides a detailed overview of the custom function code (0x45) used in the MODBUS Application Protocol. This function code is user-defined and falls within the range of 65 to 72, as specified in the MODBUS Application Protocol Specification V1.1b3 (Page 10, Section 5: Function Code Categories).
+
+
+## Introduction
+The 0x45 function code enables the implementation of user-defined logic on a remote server device. It facilitates the transmission, reception, and processing of a custom function code with a fixed-size data buffer. This buffer currently supports 4 arguments, each 2 bytes (u16) in size, allowing for the execution of custom logic remotely.
+
+**Note:** To increase flexibility, support for a variable-length data buffer will be included in a future update.
+
+
+## Request Structure
+| Parameter          | Size     | Range / Value         |
+|--------------------|----------|-----------------------|
+| Function code      | 1 Byte   | 0x45                  |
+| Length             | 2 Bytes  | 0x0004                |
+| Data               | 8 Bytes  | 0x0000 to 0xFFFF      |
+
+
+## Response Structure
+| Parameter     | Size    | Value/Description    |
+|---------------|---------|----------------------|
+| Function code | 1 Byte  | 0x45                 |
+| Length        | 2 Bytes | 0x0004               |
+| Data          | 8 Bytes | 0x0000 to 0xFFFF     |
+
+
+## Error Handling
+| Parameter      | Size    | Description                       |
+|----------------|---------|-----------------------------------|
+| Function code  | 1 Byte  | Function code + 0x80 = 0xC5 (197) |
+| Exception code | 1 Byte  | 01 or 02 or 03 or 04              |
+
+### Error Codes:
+- **01**: Illegal Function
+- **02**: Illegal Data Address
+- **03**: Illegal Data Value
+- **04**: Server Device Failure
+
+
+## Usage Example
+### Request to send the custom buffer [0xC0, 0xDE, 0xCA, 0xFE]:
+
+| Request Field             | Hex | Response Field         | Hex |
+|---------------------------|-----|------------------------|-----|
+| Function                  | 45  | Function               | 45  |
+| Length                    | 04  | Byte Count             | 04  |
+| Arg1                      | C0  | Arg1                   | C0  |
+| Arg2                      | DE  | Arg2                   | DE  |
+| Arg3                      | CA  | Arg3                   | CA  |
+| Arg4                      | FE  | Arg4                   | FE  |
+
+
+## Modify and Test Server-Side Buffer Handling
+The server currently forwards the Custom Function Code buffer to the client again without alteration. To test modifying or processing the buffer on the remote server device, edit the `write_custom_function_code()` function in `src/examples/client.rs` and `src/examples/server.rs` as needed.
+
+
+## Troubleshooting Tips
+- Ensure the server and client are using the same communication and are connected to each other.
+- Check for any error codes in the response and refer to the error handling section for resolution.
+
+
+## Additional Resources
+- For more information on the MODBUS protocol and function codes, refer to the [MODBUS Application Protocol Specification V1.1b3](https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf).

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -286,10 +286,7 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                 let result: Result<CustomFunctionCode, RequestError> = channel
                     .write_custom_function_code(
                         params,
-                        Indexed {
-                            index: (0x1),
-                            value: (0x44),
-                        },
+                        CustomFunctionCode::new(vec![0x01, 0x02, 0x03, 0x04])
                     )
                     .await;
                 print_write_result(result);

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -283,10 +283,10 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
             }
             "wcfc" => {
                 // ANCHOR: write_custom_function_code
-                let result: Result<CustomFunctionCode, RequestError> = channel
+                let result = channel
                     .write_custom_function_code(
                         params,
-                        CustomFunctionCode::new(vec![0x01, 0x02, 0x03, 0x04])
+                        CustomFunctionCode::new([0x01, 0x02, 0x03, 0x04])
                     )
                     .await;
                 print_write_result(result);

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -292,6 +292,7 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                         },
                     )
                     .await;
+                print_write_result(result);
                 // ANCHOR_END: write_custom_function_code
             }
             "rcfc" => {

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -96,7 +96,7 @@ async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
 async fn run_tls(tls_config: TlsClientConfig) -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: create_tls_channel
     let channel = spawn_tls_client_task(
-        HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 802),
+        HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 1802),
         1,
         default_retry_strategy(),
         tls_config,
@@ -178,7 +178,7 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
     channel.enable().await?;
 
     // ANCHOR: request_param
-    let params = RequestParam::new(UnitId::new(1), Duration::from_secs(1));
+    let params = RequestParam::new(UnitId::new(1), Duration::from_secs(900));
     // ANCHOR_END: request_param
 
     let mut reader = FramedRead::new(tokio::io::stdin(), LinesCodec::new());

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // ANCHOR: logging
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_max_level(tracing::Level::INFO)
         .with_target(false)
         .init();
     // ANCHOR_END: logging
@@ -61,7 +61,7 @@ where
 async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: create_tcp_channel
     let channel = spawn_tcp_client_task(
-        HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 1502),
+        HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 502),
         1,
         default_retry_strategy(),
         DecodeLevel::default(),
@@ -96,7 +96,7 @@ async fn run_rtu() -> Result<(), Box<dyn std::error::Error>> {
 async fn run_tls(tls_config: TlsClientConfig) -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: create_tls_channel
     let channel = spawn_tls_client_task(
-        HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 1802),
+        HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 802),
         1,
         default_retry_strategy(),
         tls_config,
@@ -178,7 +178,7 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
     channel.enable().await?;
 
     // ANCHOR: request_param
-    let params = RequestParam::new(UnitId::new(1), Duration::from_secs(900));
+    let params = RequestParam::new(UnitId::new(1), Duration::from_secs(1));
     // ANCHOR_END: request_param
 
     let mut reader = FramedRead::new(tokio::io::stdin(), LinesCodec::new());
@@ -198,8 +198,8 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                 channel
                     .set_decode_level(DecodeLevel::new(
                         AppDecodeLevel::DataValues,
-                        FrameDecodeLevel::Payload,
-                        PhysDecodeLevel::Data,
+                        FrameDecodeLevel::Header,
+                        PhysDecodeLevel::Length,
                     ))
                     .await?;
             }
@@ -294,11 +294,6 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                     .await;
                 print_write_result(result);
                 // ANCHOR_END: write_custom_function_code
-            }
-            "rcfc" => {
-                // ANCHOR: read_custom_function_code
-                println!("read success");
-                // ANCHOR_END: read_custom_function_code
             }
             _ => println!("unknown command"),
         }

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -281,6 +281,16 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                 print_write_result(result);
                 // ANCHOR_END: write_multiple_registers
             }
+            "wcfc" => {
+                // ANCHOR: write_custom_function_code
+                println!("write success");
+                // ANCHOR_END: write_custom_function_code
+            }
+            "rcfc" => {
+                // ANCHOR: read_custom_function_code
+                println!("success");
+                // ANCHOR_END: read_custom_function_code
+            }
             _ => println!("unknown command"),
         }
     }

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -199,7 +199,7 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                     .set_decode_level(DecodeLevel::new(
                         AppDecodeLevel::DataValues,
                         FrameDecodeLevel::Payload,
-                        PhysDecodeLevel::Length,
+                        PhysDecodeLevel::Data,
                     ))
                     .await?;
             }
@@ -284,7 +284,8 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
             "wcfc" => {
                 // ANCHOR: write_custom_function_code
                 let length = 0x04 as usize;
-                let values = [0x2, 0x3, 0x4, 0x5];
+                let values = [0x2, 0x3, 0x4, 0x5]; // i.e.: Voltage Hi = 0x02 / Voltage Lo = 0x03 / Current Hi = 0x04 / Current Lo = 0x05
+
                 let result = channel
                     .write_custom_function_code(
                         params,

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -61,7 +61,7 @@ where
 async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: create_tcp_channel
     let channel = spawn_tcp_client_task(
-        HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 502),
+        HostAddr::ip(IpAddr::V4(Ipv4Addr::LOCALHOST), 1502),
         1,
         default_retry_strategy(),
         DecodeLevel::default(),

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -283,7 +283,7 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
             }
             "wcfc" => {
                 // ANCHOR: write_custom_function_code
-                let result: Result<Indexed<u16>, RequestError> = channel
+                let result: Result<CustomFunctionCode, RequestError> = channel
                     .write_custom_function_code(
                         params,
                         Indexed {

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -283,12 +283,20 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
             }
             "wcfc" => {
                 // ANCHOR: write_custom_function_code
-                println!("write success");
+                let result: Result<Indexed<u16>, RequestError> = channel
+                    .write_custom_function_code(
+                        params,
+                        Indexed {
+                            index: (0x1),
+                            value: (0x44),
+                        },
+                    )
+                    .await;
                 // ANCHOR_END: write_custom_function_code
             }
             "rcfc" => {
                 // ANCHOR: read_custom_function_code
-                println!("success");
+                println!("read success");
                 // ANCHOR_END: read_custom_function_code
             }
             _ => println!("unknown command"),

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // ANCHOR: logging
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
+        .with_max_level(tracing::Level::DEBUG)
         .with_target(false)
         .init();
     // ANCHOR_END: logging

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -284,7 +284,7 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
             "wcfc" => {
                 // ANCHOR: write_custom_function_code
                 let length = 0x04 as usize;
-                let values = [0x2, 0x3, 0x4, 0x5]; // i.e.: Voltage Hi = 0x02 / Voltage Lo = 0x03 / Current Hi = 0x04 / Current Lo = 0x05
+                let values = [0xC0, 0xDE, 0xCA, 0xFE]; // i.e.: Voltage Hi = 0xC0 / Voltage Lo = 0xDE / Current Hi = 0xCA / Current Lo = 0xFE
 
                 let result = channel
                     .write_custom_function_code(

--- a/rodbus/examples/client.rs
+++ b/rodbus/examples/client.rs
@@ -198,7 +198,7 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
                 channel
                     .set_decode_level(DecodeLevel::new(
                         AppDecodeLevel::DataValues,
-                        FrameDecodeLevel::Header,
+                        FrameDecodeLevel::Payload,
                         PhysDecodeLevel::Length,
                     ))
                     .await?;
@@ -283,10 +283,12 @@ async fn run_channel(mut channel: Channel) -> Result<(), Box<dyn std::error::Err
             }
             "wcfc" => {
                 // ANCHOR: write_custom_function_code
+                let length = 0x04 as usize;
+                let values = [0x2, 0x3, 0x4, 0x5];
                 let result = channel
                     .write_custom_function_code(
                         params,
-                        CustomFunctionCode::new([0x01, 0x02, 0x03, 0x04])
+                        CustomFunctionCode::new(length, values)
                     )
                     .await;
                 print_write_result(result);

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -181,7 +181,7 @@ async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: tcp_server_create
     let server = rodbus::server::spawn_tcp_server_task(
         1,
-        "127.0.0.1:502".parse()?,
+        "127.0.0.1:1502".parse()?,
         map,
         AddressFilter::Any,
         DecodeLevel::default(),

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -93,7 +93,11 @@ impl RequestHandler for SimpleHandler {
     }
 
     fn write_custom_function_code(&self, values: CustomFunctionCode) -> Result<(), ExceptionCode> {
-        tracing::info!("processing custom function code, {:?}", values);
+        let mut custom_fc_args = [0_u16; 4];
+        for (i, &value) in values.iter().enumerate() {
+            custom_fc_args[i] = value;
+        }
+        tracing::info!("processing custom function code values: {:?}", custom_fc_args);
 
         Ok(())
     }

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -92,6 +92,12 @@ impl RequestHandler for SimpleHandler {
         }
     }
 
+    fn write_custom_function_code(&self, values: CustomFunctionCode) -> Result<(), ExceptionCode> {
+        tracing::info!("processing custom function code, {:?}", values);
+
+        Ok(())
+    }
+
     fn write_single_register(&mut self, value: Indexed<u16>) -> Result<(), ExceptionCode> {
         tracing::info!(
             "write single register, index: {} value: {}",

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -93,11 +93,11 @@ impl RequestHandler for SimpleHandler {
     }
 
     fn write_custom_function_code(&self, values: CustomFunctionCode) -> Result<(), ExceptionCode> {
-        let mut custom_fc_args = [0_u16; 4];
+        let mut custom_fc_args = [0_u16; 4]; // i.e.: Voltage Hi = 0x02, Voltage Lo = 0x03, Current Hi = 0x04, Current Lo = 0x05
         for (i, &value) in values.iter().enumerate() {
             custom_fc_args[i] = value;
         }
-        tracing::info!("processing custom function code values: {:?}", custom_fc_args);
+        tracing::info!("processing custom function code arguments: {:?}", custom_fc_args);
 
         Ok(())
     }
@@ -155,7 +155,7 @@ impl RequestHandler for SimpleHandler {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // initialize logging
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
+        .with_max_level(tracing::Level::DEBUG)
         .with_target(false)
         .init();
 
@@ -305,8 +305,8 @@ async fn run_server(
                 server
                     .set_decode_level(DecodeLevel::new(
                         AppDecodeLevel::DataValues,
-                        FrameDecodeLevel::Header,
-                        PhysDecodeLevel::Length,
+                        FrameDecodeLevel::Payload,
+                        PhysDecodeLevel::Data,
                     ))
                     .await?;
             }

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -92,7 +92,7 @@ impl RequestHandler for SimpleHandler {
         }
     }
 
-    fn write_custom_function_code(&self, values: CustomFunctionCode) -> Result<(), ExceptionCode> {
+    fn write_custom_function_code(&mut self, values: CustomFunctionCode) -> Result<(), ExceptionCode> {
         let mut custom_fc_args = [0_u16; 4]; // i.e.: Voltage Hi = 0x02, Voltage Lo = 0x03, Current Hi = 0x04, Current Lo = 0x05
         for (i, &value) in values.iter().enumerate() {
             custom_fc_args[i] = value;
@@ -155,7 +155,7 @@ impl RequestHandler for SimpleHandler {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // initialize logging
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_max_level(tracing::Level::INFO)
         .with_target(false)
         .init();
 
@@ -191,7 +191,7 @@ async fn run_tcp() -> Result<(), Box<dyn std::error::Error>> {
     // ANCHOR: tcp_server_create
     let server = rodbus::server::spawn_tcp_server_task(
         1,
-        "127.0.0.1:1502".parse()?,
+        "127.0.0.1:502".parse()?,
         map,
         AddressFilter::Any,
         DecodeLevel::default(),
@@ -230,7 +230,7 @@ async fn run_tls(tls_config: TlsServerConfig) -> Result<(), Box<dyn std::error::
     // ANCHOR: tls_server_create
     let server = rodbus::server::spawn_tls_server_task_with_authz(
         1,
-        "127.0.0.1:1802".parse()?,
+        "127.0.0.1:802".parse()?,
         map,
         ReadOnlyAuthorizationHandler::create(),
         tls_config,
@@ -305,8 +305,8 @@ async fn run_server(
                 server
                     .set_decode_level(DecodeLevel::new(
                         AppDecodeLevel::DataValues,
-                        FrameDecodeLevel::Payload,
-                        PhysDecodeLevel::Data,
+                        FrameDecodeLevel::Header,
+                        PhysDecodeLevel::Length,
                     ))
                     .await?;
             }

--- a/rodbus/examples/server.rs
+++ b/rodbus/examples/server.rs
@@ -230,7 +230,7 @@ async fn run_tls(tls_config: TlsServerConfig) -> Result<(), Box<dyn std::error::
     // ANCHOR: tls_server_create
     let server = rodbus::server::spawn_tls_server_task_with_authz(
         1,
-        "127.0.0.1:802".parse()?,
+        "127.0.0.1:1802".parse()?,
         map,
         ReadOnlyAuthorizationHandler::create(),
         tls_config,

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -10,6 +10,8 @@ use crate::error::*;
 use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId};
 use crate::DecodeLevel;
 
+use super::requests::write_custom_fc::WriteCustomFC;
+
 /// Async channel used to make requests
 #[derive(Debug, Clone)]
 pub struct Channel {
@@ -174,6 +176,21 @@ impl Channel {
         let request = wrap(
             param,
             RequestDetails::SendCustomBuffers(SendBuffer::new(request, Promise::channel(tx))),
+        );
+        self.tx.send(request).await?;
+        rx.await?
+    }
+
+    /// Write a Custom Function Code to the server
+    pub async fn write_custom_function_code(
+        &mut self,
+        param: RequestParam,
+        request: Indexed<u16>,
+    ) -> Result<Indexed<u16>, RequestError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<Indexed<u16>, RequestError>>();
+        let request = wrap(
+            param,
+            RequestDetails::WriteCustomFunctionCode(WriteCustomFC::new(request, Promise::channel(tx))),
         );
         self.tx.send(request).await?;
         rx.await?

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -7,7 +7,7 @@ use crate::client::requests::write_multiple::{MultipleWriteRequest, WriteMultipl
 use crate::client::requests::write_single::SingleWrite;
 use crate::client::requests::send_buffer::SendBuffer;
 use crate::error::*;
-use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId};
+use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId, CustomFunctionCode};
 use crate::DecodeLevel;
 
 use super::requests::write_custom_fc::WriteCustomFC;
@@ -185,9 +185,9 @@ impl Channel {
     pub async fn write_custom_function_code(
         &mut self,
         param: RequestParam,
-        request: Indexed<u16>,
-    ) -> Result<Indexed<u16>, RequestError> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<Result<Indexed<u16>, RequestError>>();
+        request: CustomFunctionCode,
+    ) -> Result<CustomFunctionCode, RequestError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<CustomFunctionCode, RequestError>>();
         let request = wrap(
             param,
             RequestDetails::WriteCustomFunctionCode(WriteCustomFC::new(request, Promise::channel(tx))),

--- a/rodbus/src/client/channel.rs
+++ b/rodbus/src/client/channel.rs
@@ -6,11 +6,11 @@ use crate::client::requests::read_registers::ReadRegisters;
 use crate::client::requests::write_multiple::{MultipleWriteRequest, WriteMultiple};
 use crate::client::requests::write_single::SingleWrite;
 use crate::client::requests::send_buffer::SendBuffer;
+use crate::client::requests::write_custom_fc::WriteCustomFunctionCode;
 use crate::error::*;
 use crate::types::{AddressRange, BitIterator, Indexed, RegisterIterator, UnitId, CustomFunctionCode};
 use crate::DecodeLevel;
 
-use super::requests::write_custom_fc::WriteCustomFC;
 
 /// Async channel used to make requests
 #[derive(Debug, Clone)]
@@ -190,7 +190,7 @@ impl Channel {
         let (tx, rx) = tokio::sync::oneshot::channel::<Result<CustomFunctionCode, RequestError>>();
         let request = wrap(
             param,
-            RequestDetails::WriteCustomFunctionCode(WriteCustomFC::new(request, Promise::channel(tx))),
+            RequestDetails::WriteCustomFunctionCode(WriteCustomFunctionCode::new(request, Promise::channel(tx))),
         );
         self.tx.send(request).await?;
         rx.await?

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -13,7 +13,7 @@ use crate::client::requests::write_single::SingleWrite;
 use crate::client::requests::send_buffer::SendBuffer;
 use crate::client::requests::write_custom_fc::WriteCustomFC;
 use crate::common::traits::Serialize;
-use crate::types::{Indexed, UnitId};
+use crate::types::{Indexed, UnitId, CustomFunctionCode};
 
 use scursor::{ReadCursor, WriteCursor};
 use std::time::Duration;
@@ -48,7 +48,7 @@ pub(crate) enum RequestDetails {
     WriteSingleRegister(SingleWrite<Indexed<u16>>),
     WriteMultipleCoils(MultipleWriteRequest<bool>),
     WriteMultipleRegisters(MultipleWriteRequest<u16>),
-    WriteCustomFunctionCode(WriteCustomFC<Indexed<u16>>),
+    WriteCustomFunctionCode(WriteCustomFC<CustomFunctionCode>),
 }
 
 impl Request {

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -11,6 +11,7 @@ use crate::client::requests::read_registers::ReadRegisters;
 use crate::client::requests::write_multiple::MultipleWriteRequest;
 use crate::client::requests::write_single::SingleWrite;
 use crate::client::requests::send_buffer::SendBuffer;
+use crate::client::requests::write_custom_fc::WriteCustomFC;
 use crate::common::traits::Serialize;
 use crate::types::{Indexed, UnitId};
 
@@ -47,6 +48,7 @@ pub(crate) enum RequestDetails {
     WriteSingleRegister(SingleWrite<Indexed<u16>>),
     WriteMultipleCoils(MultipleWriteRequest<bool>),
     WriteMultipleRegisters(MultipleWriteRequest<u16>),
+    WriteCustomFunctionCode(WriteCustomFC<Indexed<u16>>),
 }
 
 impl Request {
@@ -132,6 +134,7 @@ impl RequestDetails {
             RequestDetails::WriteSingleRegister(_) => FunctionCode::WriteSingleRegister,
             RequestDetails::WriteMultipleCoils(_) => FunctionCode::WriteMultipleCoils,
             RequestDetails::WriteMultipleRegisters(_) => FunctionCode::WriteMultipleRegisters,
+            RequestDetails::WriteCustomFunctionCode(_) => FunctionCode::WriteCustomFunctionCode,
         }
     }
 
@@ -146,6 +149,7 @@ impl RequestDetails {
             RequestDetails::WriteSingleRegister(x) => x.failure(err),
             RequestDetails::WriteMultipleCoils(x) => x.failure(err),
             RequestDetails::WriteMultipleRegisters(x) => x.failure(err),
+            RequestDetails::WriteCustomFunctionCode(x) => x.failure(err),
         }
     }
 
@@ -166,6 +170,9 @@ impl RequestDetails {
             RequestDetails::WriteMultipleCoils(x) => x.handle_response(cursor, function, decode),
             RequestDetails::WriteMultipleRegisters(x) => {
                 x.handle_response(cursor, function, decode)
+            },
+            RequestDetails::WriteCustomFunctionCode(x) => {
+                x.handle_response(cursor, function, decode)
             }
         }
     }
@@ -183,6 +190,7 @@ impl Serialize for RequestDetails {
             RequestDetails::WriteSingleRegister(x) => x.serialize(cursor),
             RequestDetails::WriteMultipleCoils(x) => x.serialize(cursor),
             RequestDetails::WriteMultipleRegisters(x) => x.serialize(cursor),
+            RequestDetails::WriteCustomFunctionCode(x) => x.serialize(cursor),
         }
     }
 }
@@ -249,6 +257,9 @@ impl std::fmt::Display for RequestDetailsDisplay<'_> {
                             write!(f, "\n{x}")?;
                         }
                     }
+                }
+                RequestDetails::WriteCustomFunctionCode(details) => {
+                    write!(f, "{}", details.request)?;
                 }
             }
         }

--- a/rodbus/src/client/message.rs
+++ b/rodbus/src/client/message.rs
@@ -11,7 +11,7 @@ use crate::client::requests::read_registers::ReadRegisters;
 use crate::client::requests::write_multiple::MultipleWriteRequest;
 use crate::client::requests::write_single::SingleWrite;
 use crate::client::requests::send_buffer::SendBuffer;
-use crate::client::requests::write_custom_fc::WriteCustomFC;
+use crate::client::requests::write_custom_fc::WriteCustomFunctionCode;
 use crate::common::traits::Serialize;
 use crate::types::{Indexed, UnitId, CustomFunctionCode};
 
@@ -48,7 +48,7 @@ pub(crate) enum RequestDetails {
     WriteSingleRegister(SingleWrite<Indexed<u16>>),
     WriteMultipleCoils(MultipleWriteRequest<bool>),
     WriteMultipleRegisters(MultipleWriteRequest<u16>),
-    WriteCustomFunctionCode(WriteCustomFC<CustomFunctionCode>),
+    WriteCustomFunctionCode(WriteCustomFunctionCode<CustomFunctionCode>),
 }
 
 impl Request {

--- a/rodbus/src/client/requests/mod.rs
+++ b/rodbus/src/client/requests/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod read_registers;
 pub(crate) mod write_multiple;
 pub(crate) mod write_single;
 pub(crate) mod send_buffer;
+pub(crate) mod write_custom_fc;

--- a/rodbus/src/client/requests/write_custom_fc.rs
+++ b/rodbus/src/client/requests/write_custom_fc.rs
@@ -9,22 +9,22 @@ use crate::error::RequestError;
 
 use scursor::{ReadCursor, WriteCursor};
 
-pub(crate) trait WriteCustomFCOperation: Sized + PartialEq {
+pub(crate) trait WriteCustomFunctionCodeOperation: Sized + PartialEq {
     fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError>;
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError>;
 }
 
-pub(crate) struct WriteCustomFC<T>
+pub(crate) struct WriteCustomFunctionCode<T>
 where
-    T: WriteCustomFCOperation + Display + Send + 'static,
+    T: WriteCustomFunctionCodeOperation + Display + Send + 'static,
 {
     pub(crate) request: T,
     promise: Promise<T>,
 }
 
-impl<T> WriteCustomFC<T>
+impl<T> WriteCustomFunctionCode<T>
 where
-    T: WriteCustomFCOperation + Display + Send + 'static,
+    T: WriteCustomFunctionCodeOperation + Display + Send + 'static,
 {
     pub(crate) fn new(request: T, promise: Promise<T>) -> Self {
         Self { request, promise }
@@ -66,7 +66,7 @@ where
     }
 }
 
-impl WriteCustomFCOperation for CustomFunctionCode {
+impl WriteCustomFunctionCodeOperation for CustomFunctionCode {
     fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError> {
         cursor.write_u16_be(self.len() as u16)?;
 
@@ -78,7 +78,6 @@ impl WriteCustomFCOperation for CustomFunctionCode {
 
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
         let len = cursor.read_u16_be()? as usize;
-
         let val1 = cursor.read_u16_be()?;
         let val2 = cursor.read_u16_be()?;
         let val3 = cursor.read_u16_be()?;

--- a/rodbus/src/client/requests/write_custom_fc.rs
+++ b/rodbus/src/client/requests/write_custom_fc.rs
@@ -1,0 +1,94 @@
+use std::fmt::Display;
+
+use crate::client::message::Promise;
+use crate::common::function::FunctionCode;
+use crate::decode::AppDecodeLevel;
+use crate::error::AduParseError;
+use crate::error::RequestError;
+use crate::types::{coil_from_u16, coil_to_u16, Indexed};
+
+use scursor::{ReadCursor, WriteCursor};
+
+pub(crate) trait WriteCustomFCOperation: Sized + PartialEq {
+    fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError>;
+    fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError>;
+}
+
+pub(crate) struct WriteCustomFC<T>
+where
+    T: WriteCustomFCOperation + Display + Send + 'static,
+{
+    pub(crate) request: T,
+    promise: Promise<T>,
+}
+
+impl<T> WriteCustomFC<T>
+where
+    T: WriteCustomFCOperation + Display + Send + 'static,
+{
+    pub(crate) fn new(request: T, promise: Promise<T>) -> Self {
+        Self { request, promise }
+    }
+
+    pub(crate) fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError> {
+        self.request.serialize(cursor)
+    }
+
+    pub(crate) fn failure(&mut self, err: RequestError) {
+        self.promise.failure(err)
+    }
+
+    pub(crate) fn handle_response(
+        &mut self,
+        cursor: ReadCursor,
+        function: FunctionCode,
+        decode: AppDecodeLevel,
+    ) -> Result<(), RequestError> {
+        let response = self.parse_all(cursor)?;
+
+        if decode.data_headers() {
+            tracing::info!("PDU RX - {} {}", function, response);
+        } else if decode.header() {
+            tracing::info!("PDU RX - {}", function);
+        }
+
+        self.promise.success(response);
+        Ok(())
+    }
+
+    fn parse_all(&self, mut cursor: ReadCursor) -> Result<T, RequestError> {
+        let response = T::parse(&mut cursor)?;
+        cursor.expect_empty()?;
+        if self.request != response {
+            return Err(AduParseError::ReplyEchoMismatch.into());
+        }
+        Ok(response)
+    }
+}
+
+impl WriteCustomFCOperation for Indexed<bool> {
+    fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError> {
+        cursor.write_u16_be(self.index)?;
+        cursor.write_u16_be(coil_to_u16(self.value))?;
+        Ok(())
+    }
+
+    fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
+        Ok(Indexed::new(
+            cursor.read_u16_be()?,
+            coil_from_u16(cursor.read_u16_be()?)?,
+        ))
+    }
+}
+
+impl WriteCustomFCOperation for Indexed<u16> {
+    fn serialize(&self, cursor: &mut WriteCursor) -> Result<(), RequestError> {
+        cursor.write_u16_be(self.index)?;
+        cursor.write_u16_be(self.value)?;
+        Ok(())
+    }
+
+    fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
+        Ok(Indexed::new(cursor.read_u16_be()?, cursor.read_u16_be()?))
+    }
+}

--- a/rodbus/src/client/requests/write_custom_fc.rs
+++ b/rodbus/src/client/requests/write_custom_fc.rs
@@ -78,6 +78,7 @@ impl WriteCustomFCOperation for CustomFunctionCode {
 
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
         //let len = cursor.read_u16_be()? as usize;
+        cursor.read_u16_be()?; // Skip the length field
 
         let val1 = cursor.read_u16_be()?;
         let val2 = cursor.read_u16_be()?;

--- a/rodbus/src/client/requests/write_custom_fc.rs
+++ b/rodbus/src/client/requests/write_custom_fc.rs
@@ -77,11 +77,15 @@ impl WriteCustomFCOperation for CustomFunctionCode {
     }
 
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
-        let len = cursor.read_u16_be()? as usize;
-        let mut vec = Vec::with_capacity(len);
-        for _ in 0..len {
-            vec.push(cursor.read_u16_be()?);
-        }
-        Ok(CustomFunctionCode::new(vec))
+        //let len = cursor.read_u16_be()? as usize;
+
+        let val1 = cursor.read_u16_be()?;
+        let val2 = cursor.read_u16_be()?;
+        let val3 = cursor.read_u16_be()?;
+        let val4 = cursor.read_u16_be()?;
+        
+        let values = [val1, val2, val3, val4];
+
+        Ok(CustomFunctionCode::new(values))
     }
 }

--- a/rodbus/src/client/requests/write_custom_fc.rs
+++ b/rodbus/src/client/requests/write_custom_fc.rs
@@ -77,8 +77,7 @@ impl WriteCustomFCOperation for CustomFunctionCode {
     }
 
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
-        //let len = cursor.read_u16_be()? as usize;
-        cursor.read_u16_be()?; // Skip the length field
+        let len = cursor.read_u16_be()? as usize;
 
         let val1 = cursor.read_u16_be()?;
         let val2 = cursor.read_u16_be()?;
@@ -87,6 +86,6 @@ impl WriteCustomFCOperation for CustomFunctionCode {
         
         let values = [val1, val2, val3, val4];
 
-        Ok(CustomFunctionCode::new(values))
+        Ok(CustomFunctionCode::new(len, values))
     }
 }

--- a/rodbus/src/common/function.rs
+++ b/rodbus/src/common/function.rs
@@ -10,6 +10,7 @@ mod constants {
     pub(crate) const WRITE_MULTIPLE_COILS: u8 = 15;
     pub(crate) const WRITE_MULTIPLE_REGISTERS: u8 = 16;
     pub(crate) const SEND_CUSTOM_BUFFERS: u8 = 68;
+    pub(crate) const WRITE_CUSTOM_FUNCTION_CODE: u8 = 69;
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -24,6 +25,7 @@ pub(crate) enum FunctionCode {
     WriteMultipleCoils = constants::WRITE_MULTIPLE_COILS,
     WriteMultipleRegisters = constants::WRITE_MULTIPLE_REGISTERS,
     SendCustomBuffers = constants::SEND_CUSTOM_BUFFERS,
+    WriteCustomFunctionCode = constants::WRITE_CUSTOM_FUNCTION_CODE,
 }
 
 impl Display for FunctionCode {
@@ -54,6 +56,9 @@ impl Display for FunctionCode {
             FunctionCode::SendCustomBuffers => {
                 write!(f, "SEND CUSTOM BUFFER ({:#04X})", self.get_value())
             }
+            FunctionCode::WriteCustomFunctionCode => {
+                write!(f, "WRITE CUSTOM FUNCTION CODE ({:#04X})", self.get_value())
+            }
         }
     }
 }
@@ -78,6 +83,7 @@ impl FunctionCode {
             constants::WRITE_MULTIPLE_COILS => Some(FunctionCode::WriteMultipleCoils),
             constants::WRITE_MULTIPLE_REGISTERS => Some(FunctionCode::WriteMultipleRegisters),
             constants::SEND_CUSTOM_BUFFERS => Some(FunctionCode::SendCustomBuffers),
+            constants::WRITE_CUSTOM_FUNCTION_CODE => Some(FunctionCode::WriteCustomFunctionCode),
             _ => None,
         }
     }

--- a/rodbus/src/common/parse.rs
+++ b/rodbus/src/common/parse.rs
@@ -78,4 +78,11 @@ mod coils {
         let result = Indexed::<u16>::parse(&mut cursor);
         assert_eq!(result, Ok(Indexed::new(1, 0xCAFE)));
     }
+
+    #[test]
+    fn parse_succeeds_for_valid_custom_function_code() {
+        let mut cursor = ReadCursor::new(&[0x00, 0x04, 0xCA, 0xFE, 0xC0, 0xDE, 0xCA, 0xFE, 0xC0, 0xDE]);
+        let result = crate::types::CustomFunctionCode::parse(&mut cursor);
+        assert_eq!(result, Ok(crate::types::CustomFunctionCode::new(4, [0xCAFE, 0xC0DE, 0xCAFE, 0xC0DE])));
+    }
 }

--- a/rodbus/src/common/parse.rs
+++ b/rodbus/src/common/parse.rs
@@ -30,14 +30,8 @@ impl Parse for Indexed<u16> {
 
 impl Parse for CustomFunctionCode {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
-        let len = cursor.read_u16_be()? as usize;
-
-        let val1 = cursor.read_u16_be()?;
-        let val2 = cursor.read_u16_be()?;
-        let val3 = cursor.read_u16_be()?;
-        let val4 = cursor.read_u16_be()?;
-        
-        let values = [val1, val2, val3, val4];
+        let len = cursor.read_u16_be()? as usize;        
+        let values = [cursor.read_u16_be()?, cursor.read_u16_be()?, cursor.read_u16_be()?, cursor.read_u16_be()?];
 
         Ok(CustomFunctionCode::new(len, values))
     }

--- a/rodbus/src/common/parse.rs
+++ b/rodbus/src/common/parse.rs
@@ -30,12 +30,21 @@ impl Parse for Indexed<u16> {
 
 impl Parse for CustomFunctionCode {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
-        let len = cursor.read_u16_be()? as usize;
+        /*let len = cursor.read_u16_be()? as usize;
         let mut vec = Vec::with_capacity(len);
         for _ in 0..len {
             vec.push(cursor.read_u16_be()?);
         }
-        Ok(CustomFunctionCode::new(vec))  // Construct a U16Vec from the parsed vector
+        Ok(CustomFunctionCode::new(vec))  // Construct a U16Vec from the parsed vector*/
+
+        let val1 = cursor.read_u16_be()?;
+        let val2 = cursor.read_u16_be()?;
+        let val3 = cursor.read_u16_be()?;
+        let val4 = cursor.read_u16_be()?;
+        
+        let values = [val1, val2, val3, val4];
+
+        Ok(CustomFunctionCode::new(values))
     }
 }
 

--- a/rodbus/src/common/parse.rs
+++ b/rodbus/src/common/parse.rs
@@ -1,6 +1,6 @@
 use crate::common::traits::Parse;
 use crate::error::*;
-use crate::types::{coil_from_u16, AddressRange, Indexed};
+use crate::types::{coil_from_u16, AddressRange, Indexed, CustomFunctionCode};
 
 use scursor::ReadCursor;
 
@@ -25,6 +25,17 @@ impl Parse for Indexed<bool> {
 impl Parse for Indexed<u16> {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
         Ok(Indexed::new(cursor.read_u16_be()?, cursor.read_u16_be()?))
+    }
+}
+
+impl Parse for CustomFunctionCode {
+    fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
+        let len = cursor.read_u16_be()? as usize;
+        let mut vec = Vec::with_capacity(len);
+        for _ in 0..len {
+            vec.push(cursor.read_u16_be()?);
+        }
+        Ok(CustomFunctionCode::new(vec))  // Construct a U16Vec from the parsed vector
     }
 }
 

--- a/rodbus/src/common/parse.rs
+++ b/rodbus/src/common/parse.rs
@@ -30,12 +30,8 @@ impl Parse for Indexed<u16> {
 
 impl Parse for CustomFunctionCode {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
-        /*let len = cursor.read_u16_be()? as usize;
-        let mut vec = Vec::with_capacity(len);
-        for _ in 0..len {
-            vec.push(cursor.read_u16_be()?);
-        }
-        Ok(CustomFunctionCode::new(vec))  // Construct a U16Vec from the parsed vector*/
+        //let len = cursor.read_u16_be()? as usize;
+        cursor.read_u16_be()?; // Skip the length field
 
         let val1 = cursor.read_u16_be()?;
         let val2 = cursor.read_u16_be()?;

--- a/rodbus/src/common/parse.rs
+++ b/rodbus/src/common/parse.rs
@@ -85,4 +85,11 @@ mod coils {
         let result = crate::types::CustomFunctionCode::parse(&mut cursor);
         assert_eq!(result, Ok(crate::types::CustomFunctionCode::new(4, [0xCAFE, 0xC0DE, 0xCAFE, 0xC0DE])));
     }
+
+    #[test]
+    fn parse_fails_for_invalid_custom_function_code() {
+        let mut cursor = ReadCursor::new(&[0x00, 0x04, 0xCA, 0xFE, 0xC0, 0xDE, 0xCA, 0xFE, 0xC0]);
+        let result = crate::types::CustomFunctionCode::parse(&mut cursor);
+        assert_eq!(result, Err(AduParseError::InsufficientBytes.into()));
+    }
 }

--- a/rodbus/src/common/parse.rs
+++ b/rodbus/src/common/parse.rs
@@ -30,8 +30,7 @@ impl Parse for Indexed<u16> {
 
 impl Parse for CustomFunctionCode {
     fn parse(cursor: &mut ReadCursor) -> Result<Self, RequestError> {
-        //let len = cursor.read_u16_be()? as usize;
-        cursor.read_u16_be()?; // Skip the length field
+        let len = cursor.read_u16_be()? as usize;
 
         let val1 = cursor.read_u16_be()?;
         let val2 = cursor.read_u16_be()?;
@@ -40,7 +39,7 @@ impl Parse for CustomFunctionCode {
         
         let values = [val1, val2, val3, val4];
 
-        Ok(CustomFunctionCode::new(values))
+        Ok(CustomFunctionCode::new(len, values))
     }
 }
 

--- a/rodbus/src/common/serialize.rs
+++ b/rodbus/src/common/serialize.rs
@@ -311,21 +311,13 @@ impl Loggable for CustomFunctionCode {
         if level.data_headers() {
             let mut cursor = ReadCursor::new(payload);
 
-            /*let len = match cursor.read_u16_be() {
-                Ok(len) => len,
+            let len = match cursor.read_u16_be() {
+                Ok(value) => value as usize,
                 Err(_) => return Ok(()),
             };
 
-            let mut vec = Vec::with_capacity(len as usize);
-            for _ in 0..len {
-                match cursor.read_u16_be() {
-                    Ok(value) => vec.push(value),
-                    Err(_) => return Ok(()),
-                }
-            }*/
-
             let mut data = [0_u16; 4];
-
+            
             for i in 0..4 {
                 data[i] = match cursor.read_u16_be() {
                     Ok(value) => value,
@@ -333,9 +325,10 @@ impl Loggable for CustomFunctionCode {
                 };
             }
 
-            let value = CustomFunctionCode::new(0x04, data);
+            let custom_fc = CustomFunctionCode::new(len, data);
 
-            write!(f, "{value}")?;
+            write!(f, "{:?}", custom_fc)?;
+
         }
 
         Ok(())

--- a/rodbus/src/common/serialize.rs
+++ b/rodbus/src/common/serialize.rs
@@ -333,7 +333,7 @@ impl Loggable for CustomFunctionCode {
                 };
             }
 
-            let value = CustomFunctionCode::new(data);
+            let value = CustomFunctionCode::new(0x04, data);
 
             write!(f, "{value}")?;
         }

--- a/rodbus/src/common/serialize.rs
+++ b/rodbus/src/common/serialize.rs
@@ -347,4 +347,13 @@ mod tests {
         range.serialize(&mut cursor).unwrap();
         assert_eq!(buffer, [0x00, 0x03, 0x02, 0x00]);
     }
+
+    #[test]
+    fn serializes_valid_custom_function_code() {
+        let custom_fc = CustomFunctionCode::new(4, [0xCAFE, 0xC0DE, 0xCAFE, 0xC0DE]);
+        let mut buffer = [0u8; 10];
+        let mut cursor = WriteCursor::new(&mut buffer);
+        custom_fc.serialize(&mut cursor).unwrap();
+        assert_eq!(buffer, [0x00, 0x04, 0xCA, 0xFE, 0xC0, 0xDE, 0xCA, 0xFE, 0xC0, 0xDE]);
+    }
 }

--- a/rodbus/src/common/serialize.rs
+++ b/rodbus/src/common/serialize.rs
@@ -311,7 +311,7 @@ impl Loggable for CustomFunctionCode {
         if level.data_headers() {
             let mut cursor = ReadCursor::new(payload);
 
-            let len = match cursor.read_u16_be() {
+            /*let len = match cursor.read_u16_be() {
                 Ok(len) => len,
                 Err(_) => return Ok(()),
             };
@@ -322,9 +322,18 @@ impl Loggable for CustomFunctionCode {
                     Ok(value) => vec.push(value),
                     Err(_) => return Ok(()),
                 }
+            }*/
+
+            let mut data = [0_u16; 4];
+
+            for i in 0..4 {
+                data[i] = match cursor.read_u16_be() {
+                    Ok(value) => value,
+                    Err(_) => return Ok(()),
+                };
             }
 
-            let value = CustomFunctionCode::new(vec);
+            let value = CustomFunctionCode::new(data);
 
             write!(f, "{value}")?;
         }

--- a/rodbus/src/serial/frame.rs
+++ b/rodbus/src/serial/frame.rs
@@ -88,6 +88,7 @@ impl RtuParser {
                 FunctionCode::WriteSingleRegister => LengthMode::Fixed(4),
                 FunctionCode::WriteMultipleCoils => LengthMode::Offset(5),
                 FunctionCode::WriteMultipleRegisters => LengthMode::Offset(5),
+                FunctionCode::WriteCustomFunctionCode => LengthMode::Offset(1),
             },
             ParserType::Response => match function_code {
                 FunctionCode::ReadCoils => LengthMode::Offset(1),
@@ -99,6 +100,7 @@ impl RtuParser {
                 FunctionCode::WriteSingleRegister => LengthMode::Fixed(4),
                 FunctionCode::WriteMultipleCoils => LengthMode::Fixed(4),
                 FunctionCode::WriteMultipleRegisters => LengthMode::Fixed(4),
+                FunctionCode::WriteCustomFunctionCode => LengthMode::Offset(1),
             },
         }
     }

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -327,6 +327,11 @@ impl AuthorizationHandler for ReadOnlyAuthorizationHandler {
     ) -> Authorization {
         Authorization::Deny
     }
+
+    /// Authorize a Write Custom Function Code request
+    fn write_custom_function_code(&self, _value: CustomFunctionCode, _role: &str) -> Authorization {
+        Authorization::Allow
+    }
 }
 
 #[cfg(test)]

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -69,7 +69,7 @@ pub trait RequestHandler: Send + 'static {
     }
 
     /// Write a custom function code
-    fn write_custom_function_code(&mut self, _value: CustomFunctionCode) -> Result<(), ExceptionCode> {
+    fn write_custom_function_code(&self, _values: CustomFunctionCode) -> Result<(), ExceptionCode> {
         Err(ExceptionCode::IllegalFunction)
     }
 }

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -244,6 +244,11 @@ pub trait AuthorizationHandler: Send + Sync + 'static {
     ) -> Authorization {
         Authorization::Deny
     }
+
+    /// Authorize a Write Custom Function Code request
+    fn write_custom_function_code(&self, _value: Indexed<u16>, _role: &str) -> Authorization {
+        Authorization::Deny
+    }
 }
 
 /// Read-only authorization handler that blindly accepts

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -67,6 +67,11 @@ pub trait RequestHandler: Send + 'static {
     fn write_multiple_registers(&mut self, _values: WriteRegisters) -> Result<(), ExceptionCode> {
         Err(ExceptionCode::IllegalFunction)
     }
+
+    /// Write a custom function code
+    fn write_custom_function_code(&mut self, _value: Indexed<u16>) -> Result<(), ExceptionCode> {
+        Err(ExceptionCode::IllegalFunction)
+    }
 }
 
 /// Trait useful for converting None into IllegalDataAddress

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -69,7 +69,7 @@ pub trait RequestHandler: Send + 'static {
     }
 
     /// Write a custom function code
-    fn write_custom_function_code(&self, _values: CustomFunctionCode) -> Result<(), ExceptionCode> {
+    fn write_custom_function_code(&mut self, _values: CustomFunctionCode) -> Result<(), ExceptionCode> {
         Err(ExceptionCode::IllegalFunction)
     }
 }

--- a/rodbus/src/server/handler.rs
+++ b/rodbus/src/server/handler.rs
@@ -69,7 +69,7 @@ pub trait RequestHandler: Send + 'static {
     }
 
     /// Write a custom function code
-    fn write_custom_function_code(&mut self, _value: Indexed<u16>) -> Result<(), ExceptionCode> {
+    fn write_custom_function_code(&mut self, _value: CustomFunctionCode) -> Result<(), ExceptionCode> {
         Err(ExceptionCode::IllegalFunction)
     }
 }
@@ -246,7 +246,7 @@ pub trait AuthorizationHandler: Send + Sync + 'static {
     }
 
     /// Authorize a Write Custom Function Code request
-    fn write_custom_function_code(&self, _value: Indexed<u16>, _role: &str) -> Authorization {
+    fn write_custom_function_code(&self, _value: CustomFunctionCode, _role: &str) -> Authorization {
         Authorization::Deny
     }
 }

--- a/rodbus/src/server/request.rs
+++ b/rodbus/src/server/request.rs
@@ -22,7 +22,7 @@ pub(crate) enum Request<'a> {
     WriteSingleRegister(Indexed<u16>),
     WriteMultipleCoils(WriteCoils<'a>),
     WriteMultipleRegisters(WriteRegisters<'a>),
-    WriteCustomFunctionCode(Indexed<u16>),
+    WriteCustomFunctionCode(CustomFunctionCode),
 }
 
 /// All requests that support broadcast
@@ -222,7 +222,7 @@ impl<'a> Request<'a> {
             }
             FunctionCode::WriteCustomFunctionCode => {
                 let x =
-                    Request::WriteCustomFunctionCode(Indexed::<u16>::parse(cursor)?);
+                    Request::WriteCustomFunctionCode(CustomFunctionCode::parse(cursor)?);
                 cursor.expect_empty()?;
                 Ok(x)
             }

--- a/rodbus/src/server/task.rs
+++ b/rodbus/src/server/task.rs
@@ -265,6 +265,7 @@ impl AuthorizationType {
             Request::WriteMultipleRegisters(x) => {
                 handler.write_multiple_registers(unit_id, x.range, role)
             }
+            Request::WriteCustomFunctionCode(x) => handler.write_custom_function_code(*x, role),
         }
     }
 

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -86,9 +86,9 @@ pub(crate) struct RegisterIteratorDisplay<'a> {
 }
 
 /// Custom buffer
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 pub struct CustomFunctionCode {
-    data: Vec<u16>,
+    data: [u16; 4],
 }
 
 impl std::fmt::Display for UnitId {
@@ -375,7 +375,7 @@ impl Default for UnitId {
 
 impl CustomFunctionCode {
     /// Create a new custom function code
-    pub fn new(data: Vec<u16>) -> Self {
+    pub fn new(data: [u16; 4]) -> Self {
         Self { data }
     }
 
@@ -392,7 +392,7 @@ impl CustomFunctionCode {
 
 impl std::fmt::Display for CustomFunctionCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
+        write!(f, "value: [")?;
         for (i, val) in self.data.iter().enumerate() {
             if i != 0 {
                 write!(f, ", ")?;

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -88,6 +88,7 @@ pub(crate) struct RegisterIteratorDisplay<'a> {
 /// Custom buffer
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct CustomFunctionCode {
+    len: usize,
     data: [u16; 4],
 }
 
@@ -375,8 +376,8 @@ impl Default for UnitId {
 
 impl CustomFunctionCode {
     /// Create a new custom function code
-    pub fn new(data: [u16; 4]) -> Self {
-        Self { data }
+    pub fn new(len: usize, data: [u16; 4]) -> Self {
+        Self { len, data }
     }
 
     /// Get the length of the underlying vector

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -85,7 +85,7 @@ pub(crate) struct RegisterIteratorDisplay<'a> {
     level: AppDecodeLevel,
 }
 
-/// Custom buffer
+/// Custom Function Code
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct CustomFunctionCode {
     len: usize,

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -97,6 +97,21 @@ impl std::fmt::Display for UnitId {
     }
 }
 
+impl<'a> BitIterator<'a> {
+    pub(crate) fn parse_all(
+        range: AddressRange,
+        cursor: &'a mut ReadCursor,
+    ) -> Result<Self, RequestError> {
+        let bytes = cursor.read_bytes(crate::common::bits::num_bytes_for_bits(range.count))?;
+        cursor.expect_empty()?;
+        Ok(Self {
+            bytes,
+            range,
+            pos: 0,
+        })
+    }
+}
+
 impl<'a> BitIteratorDisplay<'a> {
     pub(crate) fn new(level: AppDecodeLevel, iterator: BitIterator<'a>) -> Self {
         Self { iterator, level }

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -85,25 +85,10 @@ pub(crate) struct RegisterIteratorDisplay<'a> {
     level: AppDecodeLevel,
 }
 
-impl std::fmt::Display for UnitId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:#04X}", self.value)
-    }
-}
-
-impl<'a> BitIterator<'a> {
-    pub(crate) fn parse_all(
-        range: AddressRange,
-        cursor: &'a mut ReadCursor,
-    ) -> Result<Self, RequestError> {
-        let bytes = cursor.read_bytes(crate::common::bits::num_bytes_for_bits(range.count))?;
-        cursor.expect_empty()?;
-        Ok(Self {
-            bytes,
-            range,
-            pos: 0,
-        })
-    }
+/// Custom buffer
+#[derive(Clone, Debug, PartialEq)]
+pub struct CustomFunctionCode {
+    data: Vec<u16>,
 }
 
 impl<'a> BitIteratorDisplay<'a> {
@@ -364,6 +349,23 @@ impl UnitId {
 impl Default for UnitId {
     fn default() -> Self {
         Self { value: 0xFF }
+    }
+}
+
+impl CustomFunctionCode {
+    /// Create a new custom function code
+    pub fn new(data: Vec<u16>) -> Self {
+        Self { data }
+    }
+
+    /// Get the length of the underlying vector
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    // Iterate over the underlying vector
+    pub fn iter(&self) -> std::slice::Iter<u16> {
+        self.data.iter()
     }
 }
 

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -392,7 +392,7 @@ impl CustomFunctionCode {
 
 impl std::fmt::Display for CustomFunctionCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "value: [")?;
+        write!(f, "values: [")?;
         for (i, val) in self.data.iter().enumerate() {
             if i != 0 {
                 write!(f, ", ")?;

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -384,7 +384,7 @@ impl CustomFunctionCode {
         self.data.len()
     }
 
-    // Iterate over the underlying vector
+    /// Iterate over the underlying vector
     pub fn iter(&self) -> std::slice::Iter<u16> {
         self.data.iter()
     }

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -91,6 +91,12 @@ pub struct CustomFunctionCode {
     data: Vec<u16>,
 }
 
+impl std::fmt::Display for UnitId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#04X}", self.value)
+    }
+}
+
 impl<'a> BitIteratorDisplay<'a> {
     pub(crate) fn new(level: AppDecodeLevel, iterator: BitIterator<'a>) -> Self {
         Self { iterator, level }

--- a/rodbus/src/types.rs
+++ b/rodbus/src/types.rs
@@ -369,6 +369,19 @@ impl CustomFunctionCode {
     }
 }
 
+impl std::fmt::Display for CustomFunctionCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        for (i, val) in self.data.iter().enumerate() {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", val)?;
+        }
+        write!(f, "]")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::*;

--- a/rodbus/tests/integration_test.rs
+++ b/rodbus/tests/integration_test.rs
@@ -13,6 +13,7 @@ struct Handler {
     pub discrete_inputs: [bool; 10],
     pub holding_registers: [u16; 10],
     pub input_registers: [u16; 10],
+    pub custom_function_code: [u16; 5],
 }
 
 impl Handler {
@@ -22,6 +23,7 @@ impl Handler {
             discrete_inputs: [false; 10],
             holding_registers: [0; 10],
             input_registers: [0; 10],
+            custom_function_code: [0; 5],
         }
     }
 }
@@ -94,7 +96,17 @@ impl RequestHandler for Handler {
         }
         Ok(())
     }
-}
+
+    fn write_custom_function_code(&mut self, values: CustomFunctionCode) -> Result<(), ExceptionCode> {
+        for (i, &value) in values.iter().enumerate() {
+            match self.custom_function_code.get_mut(i) {
+                Some(c) => *c = value,
+                None => return Err(ExceptionCode::IllegalDataAddress),
+            }
+        }
+        Ok(())  
+    }
+    }
 
 async fn test_requests_and_responses() {
     let handler = Handler::new().wrap();
@@ -224,11 +236,11 @@ async fn test_requests_and_responses() {
     );
     assert_eq!(
         channel
-            .write_custom_function_code(params, CustomFunctionCode::new(4, [0xC0DE, 0xCAFE, 0xC0DE, 0xCAFE]))
+            .write_custom_function_code(params, CustomFunctionCode::new(0x04, [0xC0, 0xDE, 0xCA, 0xFE]))
             .await
             .unwrap(),
-        CustomFunctionCode::new(4, [0xC0DE, 0xCAFE, 0xC0DE, 0xCAFE])
-    )
+        CustomFunctionCode::new(4, [0xC0, 0xDE, 0xCA, 0xFE])
+    );
 }
 
 #[test]

--- a/rodbus/tests/integration_test.rs
+++ b/rodbus/tests/integration_test.rs
@@ -222,6 +222,13 @@ async fn test_requests_and_responses() {
             Indexed::new(2, 0x0506)
         ]
     );
+    assert_eq!(
+        channel
+            .write_custom_function_code(params, CustomFunctionCode::new(4, [0xC0DE, 0xCAFE, 0xC0DE, 0xCAFE]))
+            .await
+            .unwrap(),
+        CustomFunctionCode::new(4, [0xC0DE, 0xCAFE, 0xC0DE, 0xCAFE])
+    )
 }
 
 #[test]


### PR DESCRIPTION
This pull request implements a custom user-defined MODBUS function code as specified in the MODBUS Application Protocol Specification V1.1b3 (Page 10, Section 5: Function Code Categories - User-Defined Function Codes).

The Function Code 69 (0x45) enables the implementation of user-defined logic on a remote server device. It implements the transmission, reception, and processing of a custom function code with a fixed-size data buffer. This buffer currently supports up to 8 bytes or 4 arguments, each 2 bytes (u16) in size,  allowing for the remote execution of custom server-side logic.

This implementation was done by Dominik Köhler in the name of Iniationware GmbH, initialized by Klaus Landsdorf - CEO of Iniationware GmbH.

Client and Server now have support for the aforementioned Custom Function Code feature. The implemented functionality was tested with a new integration test and unit tests for parsing/serializing a Custom Function Code - and should work as expected. Let me know, if there are any issues when testing.

I've also compiled a basic feature documentation for the FC69, accessible under `rodbus\WCFC_README.md`,  feel free to modify it in any way needed.

If you have any open questions, suggestions or notes about the Custom Function Code FC69 feature, do not hesitate to let me know. I am quite new to the Rust language in traditional programming, so am always happy to learn and grow!

Dominik Köhler, Freelancer [@Iniationware](https://github.com/Iniationware)
Freelance Software Developer - Emerging Tech